### PR TITLE
chore: add Wynisco docs repo pointer in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+This guide helps both humans and AI contributors work effectively on the `WyniscoExtension` repo.
+
+---
+
+
+<!-- BEGIN: docs-repo-block (managed) -->
+## Documentation lives in the central docs repo
+
+All architecture, feature, ops, runbook, ADR, postmortem, guide, and reference docs for Wynisco live in the central docs repo, **not in this code repo**.
+
+- **Repo:** [`Wynisco-Engineering/docs`](https://github.com/Wynisco-Engineering/docs) (private)
+- **Expected local path:** sibling of this repo at `../docs/`
+- **Source of truth for structure and conventions:** the README at the root of that repo — read it before writing or moving any doc.
+
+### Rules
+
+- Do **not** create product docs, feature docs, runbooks, ops docs, ADRs, design specs, or postmortems inside this code repo.
+- This code repo keeps only: `README.md`, `CONTRIBUTING.md`, this `AGENTS.md`, code-level comments, and auto-generated API references (if any). Anything longer belongs in the docs repo.
+- When writing or updating a doc, work in `../docs/` and commit there. Cross-link from this repo's `README.md` to specific files in `../docs/` when relevant.
+
+### If `../docs/` is missing, clone it first
+
+```bash
+# from the parent directory containing this repo
+gh repo clone Wynisco-Engineering/docs docs
+cd docs && make install-hooks
+```
+
+`make install-hooks` enables the lychee pre-commit linkcheck. Install lychee once: `brew install lychee` (macOS).
+<!-- END: docs-repo-block (managed) -->


### PR DESCRIPTION
Points contributors and agents to the canonical Wynisco docs repo at [Wynisco-Engineering/docs](https://github.com/Wynisco-Engineering/docs).

## Why

- One source of truth for all product, architecture, ops, runbook, ADR, and postmortem docs across every Wynisco repo.
- Doc cadence decoupled from code CI.
- Easier discovery for new engineers, PMs, and ops.

## What

- `AGENTS.md` gets a managed `docs-repo-block` (wrapped in `BEGIN/END` markers so future updates are idempotent).
- New rule: do **not** create product / architecture / ops / runbook / ADR / postmortem docs in this code repo — they live in `../docs/`.
- Includes instructions for cloning the docs repo as a sibling if missing.
- The docs repo's `README.md` is the source of truth for structure and conventions.

## Out of scope

Existing docs in this repo (if any) are migrated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
